### PR TITLE
Update hardcoded icon hex in installation instruction, which was miss…

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ python -m ledgerblue.loadApp \
 --fileName bin/app.hex \
 --appName Radix \
 --dataSize $((0x`cat debug/app.map |grep _envram_data | tr -s ' ' | cut -f2 -d' '|cut -f2 -d'x'` - 0x`cat debug/app.map |grep _nvram_data | tr -s ' ' | cut -f2 -d' '|cut -f2 -d'x'`)) \
---icon 010000000000ffffffffffffffffffffffffe1ffe1fffc7ffc47fe4ffe1fff3fffffffffffffffffff \
+--icon 0100000000ffffff00ffffffffffffffffffe1fffdfffce7fe4ffe1fffbfffffffffffffffffffffff \
 --rootPrivateKey b5b2eacb2debcf4903060e0fa2a139354fe29be9e4ac7c433f694a3d93297eaa
 ```
 


### PR DESCRIPTION
…ed when icons were updated a couple of days ago (in [this commit](9694e4dc9b1f2439d6d5ba0019c595943d5f75ff)).

You derive this hex value from this command:

```sh
python3 /opt/bolos-devenv/nano_s_sdk_se200/icon3.py --hexbitmaponly icons/nanos_app_radix.gif
```
(Or replace with path to your Nano S SDK above)

Which is part of the `make load` execution.